### PR TITLE
fix entrez gene id field name

### DIFF
--- a/using-r-bioconductor-bccancer-march-19.Rmd
+++ b/using-r-bioconductor-bccancer-march-19.Rmd
@@ -245,7 +245,7 @@ rowData(sce)$ensembl_gene_id <- rownames(sce)
   
 sce <- getBMFeatureAnnos(sce, 
                          filters = "ensembl_gene_id",
-                         attributes = c("ensembl_gene_id", "hgnc_symbol", "entrezgene",
+                         attributes = c("ensembl_gene_id", "hgnc_symbol", "entrezgene_id",
                                         "start_position", "end_position", "chromosome_name"),
                          dataset = "hsapiens_gene_ensembl")
 


### PR DESCRIPTION
before gave error:

```
Error in biomaRt::getBM(attributes = attributes, filters = filters, values = ids,  : 
  Invalid attribute(s): entrezgene 
```